### PR TITLE
pelican.readers._EXTENSIONS -> EXTENSIONS

### DIFF
--- a/plugin/ipythonnb.py
+++ b/plugin/ipythonnb.py
@@ -1,5 +1,5 @@
 from pelican import signals
-from pelican.readers import _EXTENSIONS, Reader
+from pelican.readers import EXTENSIONS, Reader
  
 try:
     import json
@@ -52,7 +52,7 @@ class iPythonNB(Reader):
  
  
 def add_reader(arg):
-    _EXTENSIONS['ipynb'] = iPythonNB
+    EXTENSIONS['ipynb'] = iPythonNB
  
  
 def register():


### PR DESCRIPTION
I'm using pelican's master branch, and it recently removed the leading underscore from this variable.

https://github.com/getpelican/pelican/commit/12c43b7d4d9d429ddedcb729d84fa0a2e6eaff0b

P.S. Nice work on creating this plugin!
