### PR TITLE
make it work under python 2.7

### DIFF
--- a/ipythonnb.py
+++ b/ipythonnb.py
@@ -77,7 +77,7 @@ div.output_subarea {
 
 /* Forcing DataFrame table styles */
 table.dataframe {
-    font-family: Arial, sans-serif, "Microsoft YaHei";
+    font-family: Arial, sans-serif;
     font-size: 13px;
     line-height: 20px;
 }


### PR DESCRIPTION
Saw somebody requiring a python 2.x version. I've made it work for me. Somebody could give it a try.

Tested in:
Win 7
pelican 3.3.0
python 2.7.6
