### PR TITLE
summaries weren't getting generated if self.wordcount was ever EXACTLY 50

### DIFF
--- a/ipythonnb.py
+++ b/ipythonnb.py
@@ -145,7 +145,7 @@ class MyHTMLParser(HTMLReader._HTMLParser):
 
         if self.wordcount < self.settings['SUMMARY_MAX_LENGTH']:
             self.wordcount = len(strip_tags(self._data_buffer).split(' '))
-            if self.wordcount > self.settings['SUMMARY_MAX_LENGTH']:
+            if self.wordcount >= self.settings['SUMMARY_MAX_LENGTH']:
                 self.summary = self._data_buffer + '...'
 
 


### PR DESCRIPTION
1 line change - I was getting 'None' as my summary on the front page of my blog.
