### PR TITLE
  Added option for using the summary in the .ipynb-meta file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Pelican plugin for blogging with IPython Notebooks
 
-This version is modified to parse summary correctly and add a script for using MathJax.
-
 ## Requirements
 
 Python 2.7 and 3.4 are supported
@@ -102,6 +100,7 @@ to ignore it, removing it from the post content.
 
 On the `pelicanconf.py` you can use:
 
+- `IPYNB_USE_META_SUMMARY`: boolean variable to use the summary provided in the `.ipynb-meta` file instead of creating it from the notebook.
 - `IPYNB_STOP_SUMMARY_TAGS`: list of tuple with the html tag and attribute (python HTMLParser format)
 when the summary creation should stop, this is usefull to generate valid/shorter summaries.
 `default = [('div', ('class', 'input')), ('div', ('class', 'output'))]`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pelican plugin for blogging with IPython Notebooks
 
+This version is modified to parse summary correctly and add a script for using MathJax.
+
 ## Requirements
 
 Python 2.7 and 3.4 are supported

--- a/ipynb.py
+++ b/ipynb.py
@@ -109,6 +109,35 @@ table.dataframe th, td {
 </style>
 '''
 
+CUSTOM_SCRIPT = '''
+<script type="text/javascript">if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {
+    var mathjaxscript = document.createElement('script');
+    mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
+    mathjaxscript.type = 'text/javascript';
+    mathjaxscript.src = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
+    mathjaxscript[(window.opera ? "innerHTML" : "text")] =
+        "MathJax.Hub.Config({" +
+        "    config: ['MMLorHTML.js']," +
+        "    TeX: { extensions: ['AMSmath.js','AMSsymbols.js','noErrors.js','noUndefined.js'], equationNumbers: { autoNumber: 'AMS' } }," +
+        "    jax: ['input/TeX','input/MathML','output/HTML-CSS']," +
+        "    extensions: ['tex2jax.js','mml2jax.js','MathMenu.js','MathZoom.js']," +
+        "    displayAlign: 'center'," +
+        "    displayIndent: '0em'," +
+        "    showMathMenu: true," +
+        "    tex2jax: { " +
+        "        inlineMath: [ ['$','$'] ], " +
+        "        displayMath: [ ['$$','$$'] ]," +
+        "        processEscapes: true," +
+        "        preview: 'TeX'," +
+        "    }, " +
+        "    'HTML-CSS': { " +
+        "        styles: { '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {color: 'black ! important'} }" +
+        "    } " +
+        "}); ";
+    (document.body || document.getElementsByTagName('head')[0]).appendChild(mathjaxscript);
+}
+</script>	
+'''
 
 def custom_highlighter(source, language='ipython', metadata=None):
     """
@@ -218,10 +247,10 @@ class IPythonNB(BaseReader):
         parser = MyHTMLParser(self.settings, filename)
         parser.feed(content)
         parser.close()
-        body = parser.body
+        body = parser.body.replace('\[', '$$').replace('\]','$$').replace('\(', '$').replace('\)','$')
         summary = parser.summary
 
-        metadata['summary'] = summary
+        #metadata['summary'] = summary
 
         # Remove some CSS styles, so it doesn't break the themes.
         def filter_tags(style_text):
@@ -235,8 +264,7 @@ class IPythonNB(BaseReader):
 
         css = '\n'.join(filter_tags(css) for css in info['inlining']['css'])
         css = CUSTOM_CSS + css
-        body = css + body
-
+        body = css + body + CUSTOM_SCRIPT
         return body, metadata
 
 

--- a/ipynb.py
+++ b/ipynb.py
@@ -122,9 +122,10 @@ class IPythonNB(BaseReader):
         parser.feed(content)
         parser.close()
         body = parser.body
-        summary = parser.summary
-
-        metadata['summary'] = summary
+        if ('IPYNB_USE_META_SUMMARY' in self.settings.keys() and \
+          self.settings['IPYNB_USE_META_SUMMARY'] == False) or \
+          'IPYNB_USE_META_SUMMARY' not in self.settings.keys():
+            metadata['summary'] = parser.summary
 
         def filter_css(style_text):
             '''

--- a/ipynb.py
+++ b/ipynb.py
@@ -106,6 +106,104 @@ table.dataframe th, td {
     text-align: left;
 }
 
+div.cell{width:100%;padding:5px 5px 5px 0;margin:0;outline:none}
+div.prompt{min-width:11ex;padding:.4em;margin:0;font-family:monospace;text-align:right;line-height:1.21429em}
+@media (max-width:480px){div.prompt{text-align:left}}div.inner_cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+div.input_area{border:1px solid #cfcfcf;border-radius:4px;background:#f7f7f7;line-height:1.21429em}
+div.prompt:empty{padding-top:0;padding-bottom:0}
+div.input{page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}
+@media (max-width:480px){div.input{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.input_prompt{color:#000080;border-top:1px solid transparent}
+div.input_area>div.highlight{margin:.4em;border:none;padding:0;background-color:transparent}
+div.input_area>div.highlight>pre{margin:0;border:none;padding:0;background-color:transparent}
+.CodeMirror{line-height:1.21429em;height:auto;background:none;}
+.CodeMirror-scroll{overflow-y:hidden;overflow-x:auto}
+.CodeMirror-lines{padding:.4em}
+.CodeMirror-linenumber{padding:0 8px 0 4px}
+.CodeMirror-gutters{border-bottom-left-radius:4px;border-top-left-radius:4px}
+.CodeMirror pre{padding:0;border:0;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+pre code{display:block;padding:.5em}
+.highlight-base,pre code,pre .subst,pre .tag .title,pre .lisp .title,pre .clojure .built_in,pre .nginx .title{color:#000}
+.highlight-string,pre .string,pre .constant,pre .parent,pre .tag .value,pre .rules .value,pre .rules .value .number,pre .preprocessor,pre .ruby .symbol,pre .ruby .symbol .string,pre .aggregate,pre .template_tag,pre .django .variable,pre .smalltalk .class,pre .addition,pre .flow,pre .stream,pre .bash .variable,pre .apache .tag,pre .apache .cbracket,pre .tex .command,pre .tex .special,pre .erlang_repl .function_or_atom,pre .markdown .header{color:#ba2121}
+.highlight-comment,pre .comment,pre .annotation,pre .template_comment,pre .diff .header,pre .chunk,pre .markdown .blockquote{color:#408080;font-style:italic}
+.highlight-number,pre .number,pre .date,pre .regexp,pre .literal,pre .smalltalk .symbol,pre .smalltalk .char,pre .go .constant,pre .change,pre .markdown .bullet,pre .markdown .link_url{color:#080}
+pre .label,pre .javadoc,pre .ruby .string,pre .decorator,pre .filter .argument,pre .localvars,pre .array,pre .attr_selector,pre .important,pre .pseudo,pre .pi,pre .doctype,pre .deletion,pre .envvar,pre .shebang,pre .apache .sqbracket,pre .nginx .built_in,pre .tex .formula,pre .erlang_repl .reserved,pre .prompt,pre .markdown .link_label,pre .vhdl .attribute,pre .clojure .attribute,pre .coffeescript .property{color:#88f}
+.highlight-keyword,pre .keyword,pre .id,pre .phpdoc,pre .aggregate,pre .css .tag,pre .javadoctag,pre .phpdoc,pre .yardoctag,pre .smalltalk .class,pre .winutils,pre .bash .variable,pre .apache .tag,pre .go .typename,pre .tex .command,pre .markdown .strong,pre .request,pre .status{color:#008000;font-weight:bold}
+.highlight-builtin,pre .built_in{color:#008000}
+pre .markdown .emphasis{font-style:italic}
+pre .nginx .built_in{font-weight:normal}
+pre .coffeescript .javascript,pre .javascript .xml,pre .tex .formula,pre .xml .javascript,pre .xml .vbscript,pre .xml .css,pre .xml .cdata{opacity:.5}
+.cm-s-ipython span.cm-variable{color:#000}
+.cm-s-ipython span.cm-keyword{color:#008000;font-weight:bold}
+.cm-s-ipython span.cm-number{color:#080}
+.cm-s-ipython span.cm-comment{color:#408080;font-style:italic}
+.cm-s-ipython span.cm-string{color:#ba2121}
+.cm-s-ipython span.cm-builtin{color:#008000}
+.cm-s-ipython span.cm-error{color:#f00}
+.cm-s-ipython span.cm-operator{color:#a2f;font-weight:bold}
+.cm-s-ipython span.cm-meta{color:#a2f}
+.cm-s-ipython span.cm-tab{background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);background-position:right;background-repeat:no-repeat}
+div.output_wrapper{position:relative;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+div.output_scroll{height:24em;width:100%;overflow:auto;border-radius:4px;-webkit-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);-moz-box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);box-shadow:inset 0 2px 8px rgba(0,0,0,0.8);display:block}
+div.output_collapsed{margin:0;padding:0;display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+div.out_prompt_overlay{height:100%;padding:0 .4em;position:absolute;border-radius:4px}
+div.out_prompt_overlay:hover{-webkit-box-shadow:inset 0 0 1px #000;-moz-box-shadow:inset 0 0 1px #000;box-shadow:inset 0 0 1px #000;background:rgba(240,240,240,0.5)}
+div.output_prompt{color:#8b0000}
+div.output_area{padding:0;page-break-inside:avoid;display:-webkit-box;-webkit-box-orient:horizontal;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:horizontal;-moz-box-align:stretch;display:box;box-orient:horizontal;box-align:stretch;display:flex;flex-direction:row;align-items:stretch}div.output_area .MathJax_Display{text-align:left !important}
+div.output_area .rendered_html table{margin-left:0;margin-right:0}
+div.output_area .rendered_html img{margin-left:0;margin-right:0}
+.output{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}
+@media (max-width:480px){div.output_area{display:-webkit-box;-webkit-box-orient:vertical;-webkit-box-align:stretch;display:-moz-box;-moz-box-orient:vertical;-moz-box-align:stretch;display:box;box-orient:vertical;box-align:stretch;display:flex;flex-direction:column;align-items:stretch}}div.output_area pre{margin:0;padding:0;border:0;vertical-align:baseline;color:#000;background-color:transparent;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+div.output_subarea{padding:.4em .4em 0 .4em;-webkit-box-flex:1;-moz-box-flex:1;box-flex:1;flex:1}
+div.output_text{text-align:left;color:#000;line-height:1.21429em}
+div.output_stderr{background:#fdd;}
+div.output_latex{text-align:left}
+div.output_javascript:empty{padding:0}
+.js-error{color:#8b0000}
+div.raw_input_container{font-family:monospace;padding-top:5px}
+span.raw_input_prompt{}
+input.raw_input{font-family:inherit;font-size:inherit;color:inherit;width:auto;vertical-align:baseline;padding:0 .25em;margin:0 .25em}
+input.raw_input:focus{box-shadow:none}
+p.p-space{margin-bottom:10px}
+.rendered_html{color:#000;}.rendered_html em{font-style:italic}
+.rendered_html strong{font-weight:bold}
+.rendered_html u{text-decoration:underline}
+.rendered_html :link{text-decoration:underline}
+.rendered_html :visited{text-decoration:underline}
+.rendered_html h1{font-size:185.7%;margin:1.08em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h2{font-size:157.1%;margin:1.27em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h3{font-size:128.6%;margin:1.55em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h4{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1}
+.rendered_html h5{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1;font-style:italic}
+.rendered_html h6{font-size:100%;margin:2em 0 0 0;font-weight:bold;line-height:1;font-style:italic}
+.rendered_html h1:first-child{margin-top:.538em}
+.rendered_html h2:first-child{margin-top:.636em}
+.rendered_html h3:first-child{margin-top:.777em}
+.rendered_html h4:first-child{margin-top:1em}
+.rendered_html h5:first-child{margin-top:1em}
+.rendered_html h6:first-child{margin-top:1em}
+.rendered_html ul{list-style:disc;margin:0 2em}
+.rendered_html ul ul{list-style:square;margin:0 2em}
+.rendered_html ul ul ul{list-style:circle;margin:0 2em}
+.rendered_html ol{list-style:decimal;margin:0 2em}
+.rendered_html ol ol{list-style:upper-alpha;margin:0 2em}
+.rendered_html ol ol ol{list-style:lower-alpha;margin:0 2em}
+.rendered_html ol ol ol ol{list-style:lower-roman;margin:0 2em}
+.rendered_html ol ol ol ol ol{list-style:decimal;margin:0 2em}
+.rendered_html *+ul{margin-top:1em}
+.rendered_html *+ol{margin-top:1em}
+.rendered_html hr{color:#000;background-color:#000}
+.rendered_html pre{margin:1em 2em}
+.rendered_html pre,.rendered_html code{border:0;background-color:#fff;color:#000;font-size:100%;padding:0}
+.rendered_html blockquote{margin:1em 2em}
+.rendered_html table{margin-left:auto;margin-right:auto;border:1px solid #000;border-collapse:collapse}
+.rendered_html tr,.rendered_html th,.rendered_html td{border:1px solid #000;border-collapse:collapse;margin:1em 2em}
+.rendered_html td,.rendered_html th{text-align:left;vertical-align:middle;padding:4px}
+.rendered_html th{font-weight:bold}
+.rendered_html *+table{margin-top:1em}
+.rendered_html p{text-align:justify}
+.rendered_html *+p{margin-top:1em}
+.rendered_html img{display:block;margin-left:auto;margin-right:auto}
+.rendered_html *+img{margin-top:1em}
 </style>
 '''
 
@@ -263,7 +361,7 @@ class IPythonNB(BaseReader):
             return '<style type=\"text/css\">{0}</style>'.format(ans)
 
         css = '\n'.join(filter_tags(css) for css in info['inlining']['css'])
-        css = CUSTOM_CSS + css
+        css = CUSTOM_CSS #+ css
         body = css + body + CUSTOM_SCRIPT
         return body, metadata
 


### PR DESCRIPTION
A new Boolean option in pelicanconf.py, `IPYNB_USE_META_SUMMARY`, can trigger using the summary from the `.ipynb-meta` file, instead of creating it from the notebook.