### PR TITLE
Add beautifulsoup4 to list of dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Recommended version of libraries are:
 - `ipython==4.0`
 - `nbconvert==4.0`
 - `markdown==2.6.1`
+- `beautifulsoup4`
 
 There is a good chance the plugin will work correctly with older versions of Pelican and IPython.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pelican>=3.5
+jupyter
+nbconvert>=4.0
+ipython>=4.0
+markdown>=2.6.1
+beautifulsoup4


### PR DESCRIPTION
Hi,

thanks for maintaining this, it's a really neat addition to pelican.

As a suggestion, you may want to document the dependency on Beautiful Soup - I was quite confused for a little while because I couldn't get the `#ignore` functionality to work, and the failsafe BS4 import means that you'll never see an error message. This PR also adds a requirements.txt file which gets things up and running in a fresh virtualenv.