### PR TITLE
edit for python 2.X

### DIFF
--- a/core.py
+++ b/core.py
@@ -82,7 +82,7 @@ def get_html_from_filepath(filepath):
     content, info = exporter.from_filename(filepath)
 
     if BeautifulSoup:
-        soup = BeautifulSoup(content)
+        soup = BeautifulSoup(content,"html.parser")
         for i in soup.findAll("div", {"class" : "input"}):
             if i.findChildren()[1].find(text='#ignore') is not None:
                 i.extract()

--- a/markup.py
+++ b/markup.py
@@ -82,7 +82,7 @@ class IPythonNB(BaseReader):
         if 'summary' not in [key.lower() for key in self.settings.keys()]:
             content = '<body>{0}</body>'.format(content)    # So Pelican HTMLReader works
             parser = MyHTMLParser(self.settings, filename)
-            parser.feed(content)
+            parser.feed(content.decode("utf-8"))
             parser.close()
             content = parser.body
             metadata['summary'] = parser.summary


### PR DESCRIPTION
using python2.X causes UnicodeDecodeError.
line85 in markup.py needs .decode("utf-8").

and bs4 warns this:
---
UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")
---
so,line85 in core.py should be BeautifulSoup(content,"html.parser")
