### PR TITLE
Prevent wierd bytestring rendering on py3

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -80,10 +80,12 @@ class IPythonNB(BaseReader):
 
         # Generate Summary: Do it before cleaning CSS
         if 'summary' not in [key.lower() for key in self.settings.keys()]:
-            content = '<body>{0}</body>'.format(content.encode("utf-8"))    # So Pelican HTMLReader works
             parser = MyHTMLParser(self.settings, filename)
             if hasattr(content, 'decode'): # PY2
+                content = '<body>{0}</body>'.format(content.encode("utf-8"))    # So Pelican HTMLReader works
                 content = content.decode("utf-8")
+            else:
+                content = '<body>{0}</body>'.format(content)
             parser.feed(content)
             parser.close()
             content = parser.body


### PR DESCRIPTION
When using the plugin with python 3, I was seeing the following rendering:

<img width="589" alt="screen shot 2016-06-03 at 1 47 30 pm" src="https://cloud.githubusercontent.com/assets/1796208/15803015/a23c3336-2a7d-11e6-83c2-0f8f16477738.png">

This PR, should fix that.