### PR TITLE
fix for jupyter 4.1.1

### DIFF
--- a/core.py
+++ b/core.py
@@ -75,6 +75,7 @@ def get_html_from_filepath(filepath):
     exporter = HTMLExporter(config=config, template_file='basic',
                             filters={'highlight2html': custom_highlighter})
 
+    config.CSSHTMLHeaderPreprocessor.highlight_class = " .highlight pre "
     content, info = exporter.from_filename(filepath)
 
     if BeautifulSoup:


### PR DESCRIPTION
Hi, 
first, thanks for the plugin.

I am using a rather new version of jupyter and found that the style that nbconvert creates within the html file is not applied for some of the pelican themes, such as pelican-bootstrap3.
One reason is that the nbconvert API may have changed slightly.
Also, the pygments output is wrapped in a pre-tag, which I add to the nbconvert css.
This is not a robust solution as it makes many assumptions and is not configurable, mostly because I am not familiar with all the tools :)
Please let me know what you think.
Thanks!
