### PR TITLE
Fix UnicodeEncodeError in issue #54

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import json
+import six
 
 try:
     # Py3k
@@ -82,9 +83,9 @@ class IPythonNB(BaseReader):
         # Generate Summary: Do it before cleaning CSS
         if 'summary' not in [key.lower() for key in self.settings.keys()]:
             parser = MyHTMLParser(self.settings, filename)
-            if hasattr(content, 'decode'): # PY2
-                content = '<body>{0}</body>'.format(content.encode("utf-8"))    # So Pelican HTMLReader works
-                content = content.decode("utf-8")
+            if isinstance(content, six.binary_type): # PY2 (str) or PY3 (bytes) to PY2 (unicode) or PY3 (str)
+                # unicode_literals makes format() try to decode as ASCII. Enforce decoding as UTF-8.
+                content = '<body>{0}</body>'.format(content.decode("utf-8"))
             else:
                 # Content already decoded
                 content = '<body>{0}</body>'.format(content)


### PR DESCRIPTION
This fixes issue #54. The first error was a non-error one. I just mistook it for an error because the error message had misplaced encoding.

The second error is in line 87. It appears the check for `content` attribute `decode` was bogus in two ways:

1. `content` here may be `str` or `unicode`. I properly checked the correct type with `six.binary_type`.
2. `content` was being `decoded` and then joined (through `format()`) to a `unicode` string, due to `unicode_literals`. This causes `format()` to try to decode the just-encoded bytes as ASCII, causing the error.

`six` as a new dependency shouldn't be a problem since it is [recommended by the Pelican contributors blog](http://blog.getpelican.com/pelicans-unified-codebase.html) and is also used by Pelican itself.