### PR TITLE
ENH: allow cells[start:end] in liquid

### DIFF
--- a/liquid.py
+++ b/liquid.py
@@ -8,8 +8,14 @@ from liquid_tags.mdx_liquid_tags import LiquidTags
 from .core import get_html_from_filepath, fix_css
 
 
-SYNTAX = "{% notebook ~/absolute/path/to/notebook.ipynb %}"
-FORMAT = re.compile(r"""^(\s+)?(?P<src>\S+)(\s+)?((cells\[)(?P<start>-?[0-9]*):(?P<end>-?[0-9]*)(\]))?(\s+)?((language\[)(?P<language>-?[a-z0-9\+\-]*)(\]))?(\s+)?$""")
+SYNTAX = "{% notebook ~/absolute/path/to/notebook.ipynb [cells[start:end]] %}"
+FORMAT = re.compile(r"""
+^(\s+)?                                                # whitespace
+(?P<src>\S+)                                           # source path
+(\s+)?                                                 # whitespace
+((cells\[)(?P<start>-?[0-9]*):(?P<end>-?[0-9]*)(\]))?  # optional cells
+(\s+)?$                                                # whitespace
+""", re.VERBOSE)
 
 @LiquidTags.register('notebook')
 def notebook(preprocessor, tag, markup):
@@ -19,14 +25,16 @@ def notebook(preprocessor, tag, markup):
         src = argdict['src']
         start = argdict['start']
         end = argdict['end']
-        language = argdict['language']
     else:
         raise ValueError("Error processing input, "
                          "expected syntax: {0}".format(SYNTAX))
 
+    start = int(start) if start else 0
+    end = int(end) if end else None
+
     # nb_dir =  preprocessor.configs.getConfig('NOTEBOOK_DIR')
     nb_path = os.path.join('content', src)
-    content, info = get_html_from_filepath(nb_path)
+    content, info = get_html_from_filepath(nb_path, start=start, end=end)
     ignore_css = preprocessor.configs.getConfig('IPYNB_IGNORE_CSS', False)
     content = fix_css(content, info, ignore_css=ignore_css)
     content = preprocessor.configs.htmlStash.store(content, safe=True)


### PR DESCRIPTION
This brings over the ``cells[start:end]`` syntax from liquid tags. I find this useful when I want to compose a blog post in a notebook, but also have the notebook available for download. Using this I can skip some intro cells (such as the title and a note about the blog post) without needing two copies of the notebook.