### PR TITLE
Allow MathJax to break equations.

### DIFF
--- a/core.py
+++ b/core.py
@@ -68,6 +68,7 @@ LATEX_CUSTOM_SCRIPT = """
         "        preview: 'TeX'," +
         "    }, " +
         "    'HTML-CSS': { " +
+        " linebreaks: { automatic: true, width: '95% container' }, " +
         "        styles: { '.MathJax_Display, .MathJax .mo, .MathJax .mi, .MathJax .mn': {color: 'black ! important'} }" +
         "    } " +
         "}); ";


### PR DESCRIPTION
Minor change to allow MathJax to break lines -- useful for long equations, especially on mobiles--