### PR TITLE
Adding support for nbconvert preprocessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Jupyter Notebook is based on bootstrap so you probably will need your theme to b
 
 I try to inject only the necessary CSS, removing Jupyter's bootstrap but fixes are needed in some cases,
 if you find this issues I recommend looking at how my theme fixes them. You can suppress the inclusion of CSS entirely by setting
-`IPYNB_IGNORE_CSS=True` in `pelicanconf.py`. 
+`IPYNB_IGNORE_CSS=True` in `pelicanconf.py`.
 
 
 ## Options
@@ -181,3 +181,4 @@ when the summary creation should stop, this is usefull to generate valid/shorter
 - `IPYNB_EXTEND_STOP_SUMMARY_TAGS`: list of tuples to extend the default `IPYNB_STOP_SUMMARY_TAGS`
 - `IGNORE_FILES = ['.ipynb_checkpoints']`: prevents pelican from trying to parse notebook checkpoint files
 - `IPYNB_IGNORE_CSS = True`: do not include the notebook CSS in the generated output
+- `IPYNB_PREPROCESSORS`: a list of nbconvert preprocessors to be used when generating the HTML output

--- a/core.py
+++ b/core.py
@@ -78,16 +78,20 @@ LATEX_CUSTOM_SCRIPT = """
 """
 
 
-def get_html_from_filepath(filepath, start=0, end=None):
+def get_html_from_filepath(filepath, start=0, end=None, preprocessors=[]):
     """Convert ipython notebook to html
     Return: html content of the converted notebook
     """
-    config = Config({'CSSHTMLHeaderTransformer': {'enabled': True,
-                     'highlight_class': '.highlight-ipynb'},
-                     'SubCell': {'enabled':True, 'start':start, 'end':end}})
+    config = Config({'CSSHTMLHeaderTransformer': {
+                        'enabled': True,
+                        'highlight_class': '.highlight-ipynb'},
+                     'SubCell': {
+                        'enabled':True,
+                        'start':start,
+                        'end':end}})
     exporter = HTMLExporter(config=config, template_file='basic',
                             filters={'highlight2html': custom_highlighter},
-                            preprocessors=[SubCell])
+                            preprocessors=[SubCell] + preprocessors)
     content, info = exporter.from_filename(filepath)
 
     if BeautifulSoup:

--- a/markup.py
+++ b/markup.py
@@ -78,7 +78,7 @@ class IPythonNB(BaseReader):
                 raise Exception("Could not find metadata in `.ipynb-meta` or inside `.ipynb` but found `.md` file, "
                       "assuming that this notebook is for liquid tag usage if true ignore this error")
 
-        content, info = get_html_from_filepath(filepath)
+        content, info = get_html_from_filepath(filepath, preprocessors=self.settings.get('IPYNB_PREPROCESSORS', []))
 
         # Generate Summary: Do it before cleaning CSS
         if 'summary' not in [key.lower() for key in self.settings.keys()]:


### PR DESCRIPTION
This commit adds support for specifying a list of nbconvert preprocessors to be used when converting the document. 

I ran into an issue when trying to use the [Python Markdown](http://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/python-markdown/readme.html) nbconvert extension. I needed a way of passing in preprocessors to be used during the conversion from a notebook file to HTML. This PR contains support for a new config option, `IPYNB_PREPROCESSORS`, that expects a list of preprocessors that will be used during the generation of HTML output.