### PR TITLE
Finding ipynb-meta files fails if filename contains '.'

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -48,7 +48,7 @@ class IPythonNB(BaseReader):
         # Files
         filedir = os.path.dirname(filepath)
         filename = os.path.basename(filepath)
-        metadata_filename = filename.split('.')[0] + '.ipynb-meta'
+        metadata_filename = os.path.splitext(filename)[0] + '.ipynb-meta'
         metadata_filepath = os.path.join(filedir, metadata_filename)
 
         if os.path.exists(metadata_filepath):


### PR DESCRIPTION
File discovery will fail when `.ipynb-meta` files contains `.` in the name.
I think the fix is to replace `filename.split('.')[0]` with `os.path.splitext(filename)[0]`

I was having issued when the file was named "04.09.09.post.ipynb", but it works after this fix.