### PR TITLE
add "additional_tags" and "status" metatags in the metadata ipynb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ Edit this the `metadata` tag to have the required markdown metadata:
     { A_LOT_OF_OTHER_STUFF }
 ```
 
-Additional meta-tags can be placed inside an `"extras"` object inside the `metadata`, which can be accessed directly inside the pelican themes.
+Additional meta-tags can be placed inside an `"Extras"` object inside the `metadata`, which can be accessed directly inside the pelican themes.
 
 ```
 {
  "metadata": {
         "name": "My notebook",
         "Title": "Notebook using internal metadata",
-        "extras": {
+        "Extras": {
            "Modified": "2017-04-30 08:58"
         }
         

--- a/README.md
+++ b/README.md
@@ -110,16 +110,20 @@ Edit this the `metadata` tag to have the required markdown metadata:
     { A_LOT_OF_OTHER_STUFF }
 ```
 
-Additional meta-tags can be placed inside an `"Extras"` object inside the `metadata`, which can be accessed directly inside the pelican themes.
+By default, the following keys can are read inside the metadata object:
+```
+"Title", "Date", "Category", "Tags", "Slug", "Author", "Status"
+```
+
+Additional meta-tag names can be placed inside an `"additional_tags"` list inside the `metadata` object in order to expand the above list. additional keys can be accessed directly inside the pelican themes.
 
 ```
 {
  "metadata": {
         "name": "My notebook",
         "Title": "Notebook using internal metadata",
-        "Extras": {
-           "Modified": "2017-04-30 08:58"
-        }
+        "additional_tags": ["Modified"],
+        "Modified": "2017-04-30 08:58"
         
         ... { A_LOT_OF_OTHER_STUFF } ...
     },

--- a/README.md
+++ b/README.md
@@ -102,11 +102,37 @@ Edit this the `metadata` tag to have the required markdown metadata:
         "Category": "Category",
         "Tags": "tag1,tag2",
         "slug": "with-metadata",
-        "Author": "Me"
+        "Author": "Me",
+        "Status": "published"
 
         ... { A_LOT_OF_OTHER_STUFF } ...
     },
     { A_LOT_OF_OTHER_STUFF }
+```
+
+Additional meta-tags can be placed inside an `"extras"` object inside the `metadata`, which can be accessed directly inside the pelican themes.
+
+```
+{
+ "metadata": {
+        "name": "My notebook",
+        "Title": "Notebook using internal metadata",
+        "extras": {
+           "Modified": "2017-04-30 08:58"
+        }
+        
+        ... { A_LOT_OF_OTHER_STUFF } ...
+    },
+    { A_LOT_OF_OTHER_STUFF }
+```
+
+Usage inside a pelican theme:
+
+```
+<!-- articles.html -->
+{% if article.modified %}
+Last modified: {{ article.modified }}
+{% endif %}
 ```
 
 ## Mode B: Liquid Tags

--- a/markup.py
+++ b/markup.py
@@ -61,17 +61,17 @@ class IPythonNB(BaseReader):
             ipynb_file = open(filepath)
             notebook_metadata = json.load(ipynb_file)['metadata']
 
-            additional_metatags = notebook_metadata['additional_tags'] if 'additional_tags' in notebook_metadata else []
+            ADDITIONAL_TAGS = 'additional_tags'
+            original_tags = ("title", "date", "category", "tags", "slug", "author", "status")
+            additional_metatags = notebook_metadata[ADDITIONAL_TAGS] if ADDITIONAL_TAGS in notebook_metadata else ()
             
+            metatags = set(original_tags + tuple(additional_metatags))
+
             # Change to standard pelican metadata
             for key, value in notebook_metadata.items():
                 key = key.lower()
-                if key in ("title", "date", "category", "tags", "slug", "author", "status"):
+                if key in metatags:
                     metadata[key] = self.process_metadata(key, value)
-                for additional_key in additional_metatags:
-                    additional_key = additional_key.lower()
-                    if key == additional_key:
-                        metadata[key] = self.process_metadata(additional_key, value)
                         
 
         keys = [k.lower() for k in metadata.keys()]

--- a/markup.py
+++ b/markup.py
@@ -64,7 +64,7 @@ class IPythonNB(BaseReader):
             # Change to standard pelican metadata
             for key, value in notebook_metadata.items():
                 key = key.lower()
-                if key in ("title", "date", "category", "tags", "slug", "author"):
+                if key in ("title", "date", "category", "tags", "slug", "author", "status"):
                     metadata[key] = self.process_metadata(key, value)
                 if key = "extras" and type(key) is dict:
                     metadata["extras"] = {};

--- a/markup.py
+++ b/markup.py
@@ -48,7 +48,7 @@ class IPythonNB(BaseReader):
         # Files
         filedir = os.path.dirname(filepath)
         filename = os.path.basename(filepath)
-        metadata_filename = filename.split('.')[0] + '.ipynb-meta'
+        metadata_filename = os.path.splitext(filename)[0] + '.ipynb-meta'
         metadata_filepath = os.path.join(filedir, metadata_filename)
 
         if os.path.exists(metadata_filepath):
@@ -72,6 +72,7 @@ class IPythonNB(BaseReader):
                     additional_key = additional_key.lower()
                     if key == additional_key:
                         metadata[key] = self.process_metadata(additional_key, value)
+                        
 
         keys = [k.lower() for k in metadata.keys()]
         if not set(['title', 'date']).issubset(set(keys)):

--- a/markup.py
+++ b/markup.py
@@ -66,6 +66,11 @@ class IPythonNB(BaseReader):
                 key = key.lower()
                 if key in ("title", "date", "category", "tags", "slug", "author"):
                     metadata[key] = self.process_metadata(key, value)
+                if key = "extras" and type(key) is dict:
+                    metadata["extras"] = {};
+                    for extras_key in value:
+                        metadata["extras"][extras_key] = self.process_metadata(extras_key, value)
+                        
 
         keys = [k.lower() for k in metadata.keys()]
         if not set(['title', 'date']).issubset(set(keys)):

--- a/markup.py
+++ b/markup.py
@@ -48,7 +48,7 @@ class IPythonNB(BaseReader):
         # Files
         filedir = os.path.dirname(filepath)
         filename = os.path.basename(filepath)
-        metadata_filename = os.path.splitext(filename)[0] + '.ipynb-meta'
+        metadata_filename = filename.split('.')[0] + '.ipynb-meta'
         metadata_filepath = os.path.join(filedir, metadata_filename)
 
         if os.path.exists(metadata_filepath):
@@ -61,16 +61,17 @@ class IPythonNB(BaseReader):
             ipynb_file = open(filepath)
             notebook_metadata = json.load(ipynb_file)['metadata']
 
+            additional_metatags = notebook_metadata['additional_tags'] if 'additional_tags' in notebook_metadata else []
+            
             # Change to standard pelican metadata
             for key, value in notebook_metadata.items():
                 key = key.lower()
                 if key in ("title", "date", "category", "tags", "slug", "author", "status"):
                     metadata[key] = self.process_metadata(key, value)
-                if key = "extras" and type(key) is dict:
-                    metadata["extras"] = {};
-                    for extras_key in value:
-                        metadata["extras"][extras_key] = self.process_metadata(extras_key, value)
-                        
+                for additional_key in additional_metatags:
+                    additional_key = additional_key.lower()
+                    if key == additional_key:
+                        metadata[key] = self.process_metadata(additional_key, value)
 
         keys = [k.lower() for k in metadata.keys()]
         if not set(['title', 'date']).issubset(set(keys)):

--- a/markup.py
+++ b/markup.py
@@ -65,7 +65,7 @@ class IPythonNB(BaseReader):
             original_tags = ("title", "date", "category", "tags", "slug", "author", "status")
             additional_metatags = notebook_metadata[ADDITIONAL_TAGS] if ADDITIONAL_TAGS in notebook_metadata else ()
             
-            metatags = set(original_tags + tuple(additional_metatags))
+            metatags = set(original_tags + tuple(add_tag.lower() for add_tag in additional_metatags))
 
             # Change to standard pelican metadata
             for key, value in notebook_metadata.items():


### PR DESCRIPTION
having the metadata inside the ipynb file restricts the user to only a handful of metatags:

```
"title", "date", "category", "tags", "slug", "author"
```

This pull request adds an additional meta-tag "additional_tags" list inside the metadata object in order to expand the above list. additional keys can be accessed directly inside the pelican themes.

additionally, to fix #59 (the `status: 'draft'` issue when using ipynb metadata dict) i added "status" to the keys to check against in the metadata aswell.

# Example 
```
# inside the .ipynb file
{
   "metadata": {
      "additional_tags": ["Modified"],
      "Modified": "2017-04-30 08:58",
      "status": "draft"
}
```

usage inside a pelican theme:

```
<!-- articles.html -->
{% if article.modified %}
Last modified: {{ article.modified }}
{% endif %}
```
