### PR TITLE
fix mathjax cdn

### DIFF
--- a/core.py
+++ b/core.py
@@ -51,7 +51,7 @@ LATEX_CUSTOM_SCRIPT = """
     var mathjaxscript = document.createElement('script');
     mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
     mathjaxscript.type = 'text/javascript';
-    mathjaxscript.src = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
+    mathjaxscript.src = '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
     mathjaxscript[(window.opera ? "innerHTML" : "text")] =
         "MathJax.Hub.Config({" +
         "    config: ['MMLorHTML.js']," +


### PR DESCRIPTION
From #70: [MathJax CDN shutting down on April 30, 2017](https://www.mathjax.org/cdn-shutting-down/). 

Although it is small, the bug is in a sense urgent, I am opening this pull request to fix the bug. 