### PR TITLE
Generate valid HTML for HTML-based strings.

### DIFF
--- a/core.py
+++ b/core.py
@@ -81,7 +81,7 @@ def get_html_from_filepath(filepath):
         for i in soup.findAll('div', {'class': 'input'}):
             if i.findChildren()[1].find(text='#ignore') is not None:
                 i.extract()
-        content = soup.decode(formatter=None)
+        content = soup.decode(formatter="minimal")
 
     return content, info
 


### PR DESCRIPTION
Fix invalid HTML output when using BeautifulSoup to decode content.

Consider this input cell:
```python
html = """<div><table border="1" class="dataframe"><thead><tr style="text-align:right;"><th></th><th>x</th><th>y</th></tr></thead><tbody><tr><th>0</th><td>-2.863752</td><td>-1.066424</td></tr><tr><th>1</th><td>-0.779238</td><td>0.862169</td></tr></tbody></table></div>"""
```

When decode using `None` formatter with [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#output-formatters)

```python
soup = BeautifulSoup(content, 'html.parser')
content = soup.decode(formatter=None)
```

The HTML value inside string is parsed as table in static file, which is not desired as we want a code block here.
![invalid_html](https://user-images.githubusercontent.com/3454980/36969739-b9b8a07a-20a9-11e8-9c7e-8764d5ace650.png)

By using `soup.decode(formatter="minimal")` which suggested by [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#output-formatters), we get following result:

![valid_html](https://user-images.githubusercontent.com/3454980/36969796-e05a7ca8-20a9-11e8-98ab-b8889eadfd41.png)






