### PR TITLE
feature: Add support for python markdown and image attachments

### DIFF
--- a/markup.py
+++ b/markup.py
@@ -14,8 +14,7 @@ except ImportError:
 from pelican import signals
 from pelican.readers import MarkdownReader, HTMLReader, BaseReader
 
-from .ipynb import get_html_from_filepath, fix_css
-
+from .ipynb import get_html_from_filepath, fix_css, copy_images
 
 def register():
     """
@@ -79,6 +78,7 @@ class IPythonNB(BaseReader):
                       "assuming that this notebook is for liquid tag usage if true ignore this error")
 
         content, info = get_html_from_filepath(filepath)
+        copy_images(filepath, self.settings['OUTPUT_PATH'])
 
         # Generate Summary: Do it before cleaning CSS
         if 'summary' not in [key.lower() for key in self.settings.keys()]:
@@ -100,7 +100,6 @@ class IPythonNB(BaseReader):
         ignore_css = True if 'IPYNB_IGNORE_CSS' in self.settings.keys() else False
         content = fix_css(content, info, ignore_css=ignore_css)
         return content, metadata
-
 
 class MyHTMLParser(HTMLReader._HTMLParser):
     """
@@ -125,6 +124,7 @@ class MyHTMLParser(HTMLReader._HTMLParser):
             self.stop_tags = self.settings['IPYNB_STOP_SUMMARY_TAGS']
         if 'IPYNB_EXTEND_STOP_SUMMARY_TAGS' in self.settings.keys():
             self.stop_tags.extend(self.settings['IPYNB_EXTEND_STOP_SUMMARY_TAGS'])
+
 
     def handle_starttag(self, tag, attrs):
         HTMLReader._HTMLParser.handle_starttag(self, tag, attrs)


### PR DESCRIPTION
I updated the code to work with Python Markdown extension:

https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/python-markdown

It will likely work with other Jupyter extensions as well since it uses `jupyter nbconvert` shell command to get content now.

I also adjusted the code so that the system copies all images to `output` directory. It does not currently work with attachments since I do not use them myself. To include image, use the following Markdown syntax:
```
![image](image.url.jpg)
```