### PR TITLE
Add new "metacell" option, where metadata is extracted from the first notebook cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ PLUGIN_PATHS = ['./plugins']
 PLUGINS = ['ipynb.markup']
 ```
 
-### Option 1 (recommended)
+### Option 1 (recommended): separate metadata file
 
 Write the post using the Jupyter Notebook interface, using markdown, equations, etc.
 
@@ -78,7 +78,7 @@ Summary:
 
 ```
 
-### Option 2
+### Option 2: metadata field in notebook
 
 Open the `.ipynb` file in a text editor and look for the `metadata` tag should see.
 
@@ -107,6 +107,30 @@ Edit this the `metadata` tag to have the required markdown metadata:
         ... { A_LOT_OF_OTHER_STUFF } ...
     },
     { A_LOT_OF_OTHER_STUFF }
+```
+
+### Option 3: metadata cell in notebook
+
+With this option, the metadata is extracted from the first cell of
+the notebook (which should be a Markdown cell).
+This avoid the burden of maintaining a separate file or manually editing the
+json in the `.ipynb` file like the previous options.
+
+First, enable the "metacell" mode globally in your config
+
+```python
+IPYNB_USE_METACELL = True
+```
+
+Now, you can put the metadata in the first notebook cell in Markdown mode,
+like this:
+
+```markdown
+# How to install pip
+- author: John Doe
+- date: 2018-05-11
+- category: pyhton
+- tags: pip
 ```
 
 ## Mode B: Liquid Tags

--- a/markup.py
+++ b/markup.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import json
+import re
 import six
+import tempfile
 
 try:
     # Py3k
@@ -44,6 +46,7 @@ class IPythonNB(BaseReader):
     def read(self, filepath):
         metadata = {}
         metadata['ipython'] = True
+        start = 0
 
         # Files
         filedir = os.path.dirname(filepath)
@@ -51,21 +54,35 @@ class IPythonNB(BaseReader):
         metadata_filename = os.path.splitext(filename)[0] + '.ipynb-meta'
         metadata_filepath = os.path.join(filedir, metadata_filename)
 
+        # When metadata is in a external file, process using Pelican MD Reader
+        md_reader = MarkdownReader(self.settings)
+
         if os.path.exists(metadata_filepath):
-            # Metadata is on a external file,
-            # process using Pelican MD Reader
-            md_reader = MarkdownReader(self.settings)
             _content, metadata = md_reader.read(metadata_filepath)
         else:
             # Load metadata from ipython notebook file
-            ipynb_file = open(filepath)
-            notebook_metadata = json.load(ipynb_file)['metadata']
-
-            # Change to standard pelican metadata
-            for key, value in notebook_metadata.items():
-                key = key.lower()
-                if key in ("title", "date", "category", "tags", "slug", "author"):
-                    metadata[key] = self.process_metadata(key, value)
+            with open(filepath) as ipynb_file:
+                doc = json.load(ipynb_file)
+            if self.settings.get('IPYNB_USE_METACELL'):
+                metacell = "\n".join(doc['cells'][0]['source'])
+                # Convert Markdown title and listings to standard metadata items
+                metacell = re.sub(r'^#+\s+', 'title: ', metacell, flags=re.MULTILINE)
+                metacell = re.sub(r'^\s*[*+-]\s+', '', metacell, flags=re.MULTILINE)
+                # Unfortunately we can not pass MarkdownReader a in-memory
+                # string, so we have to work with a temporary file
+                with tempfile.NamedTemporaryFile('w+', encoding='utf-8') as metadata_file:
+                    metadata_file.write(metacell)
+                    metadata_file.flush()
+                    _content, metadata = md_reader.read(metadata_file.name)
+                # Skip metacell
+                start = 1
+            else:
+                notebook_metadata = doc['metadata']
+                # Change to standard pelican metadata
+                for key, value in notebook_metadata.items():
+                    key = key.lower()
+                    if key in ("title", "date", "category", "tags", "slug", "author"):
+                        metadata[key] = self.process_metadata(key, value)
 
         keys = [k.lower() for k in metadata.keys()]
         if not set(['title', 'date']).issubset(set(keys)):
@@ -78,7 +95,7 @@ class IPythonNB(BaseReader):
                 raise Exception("Could not find metadata in `.ipynb-meta` or inside `.ipynb` but found `.md` file, "
                       "assuming that this notebook is for liquid tag usage if true ignore this error")
 
-        content, info = get_html_from_filepath(filepath)
+        content, info = get_html_from_filepath(filepath, start=start)
 
         # Generate Summary: Do it before cleaning CSS
         if 'summary' not in [key.lower() for key in self.settings.keys()]:


### PR DESCRIPTION
Concept based on https://github.com/peijunz/ipynb2pelican, where the metadata is extracted from the first cell of the notebook.
This makes things easier because the metadata can trivially be managed from within the notebook (no need for a separate `.ipynb-meta` file or manually editing the `.ipynb` json)