### PR TITLE
Add ignore suggestions to pelicanconf.py setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ MARKUP = ('md', 'ipynb')
 
 PLUGIN_PATHS = ['./plugins']
 PLUGINS = ['ipynb.markup']
+
+# if you create jupyter files in the content dir, snapshots are saved with the same
+# metadata. These need to be ignored. 
+IGNORE_FILES = [".ipynb_checkpoints"]  
 ```
 
 ### Option 1: Separate MD metadata file


### PR DESCRIPTION
I was creating my jupyter notebooks directly in the content dir and was getting an error since the pelican processor would see both the checkpoints and the ipynb files which would have identical metdata and be rather confused.

```
WARNING: There are 2 items with slug "tosser" with lang en:
  | /Users/varun/Documents/github/nayyarv.github.io/content/Tosser.ipynb
  | /Users/varun/Documents/github/nayyarv.github.io/content/.ipynb_checkpoints/Tosser-checkpoint.ipynb
WARNING: There are 2 original (not translated) items with slug "tosser":
  | /Users/varun/Documents/github/nayyarv.github.io/content/Tosser.ipynb
  | /Users/varun/Documents/github/nayyarv.github.io/content/.ipynb_checkpoints/Tosser-checkpoint.ipynb
CRITICAL: RuntimeError: File /Users/varun/Documents/github/nayyarv.github.io/output/tosser.html is to be overwritten
make: *** [html] Error 1
```

I think it might not be a bad idea to include an ignore section in your doc as well so people like me are sorted from the get go!